### PR TITLE
Heroセクションの開催日・会場情報を最新化

### DIFF
--- a/src/app/_components/sections/HeroSection.tsx
+++ b/src/app/_components/sections/HeroSection.tsx
@@ -25,7 +25,11 @@ export default function HeroSection() {
           </div>
           <div className='flex lg:flex-row flex-col justify-between mt-2'>
             <p>Venue:&nbsp;</p>
-            <p>{Conference.locationEn}</p>
+            <p>{Conference.conferenceLocationEn}</p>
+          </div>
+          <div className='flex lg:flex-row flex-col justify-between'>
+            <p/>
+            <p>{Conference.sprintLocationEn}</p>
           </div>
         </div>
         <div className='pt-4 z-10 lg:text-sm text-xs'>

--- a/src/app/variables.ts
+++ b/src/app/variables.ts
@@ -28,11 +28,12 @@ export type Keynote = {
 export const Conference = {
   name: 'PyCon JP 2026',
   conferenceDateJa: '2026年08月21日-2026年08月22日 カンファレンス',
-  sprintDateJa: '2026年08月23日 スプリント(仮)',
+  sprintDateJa: '2026年08月23日 スプリント',
   conferenceDateEn: 'August 21-22, 2026 Conference Days',
-  sprintDateEn: 'August 23, 2026 Sprint Day (tentative)',
-  locationJa: '広島国際会議場',
-  locationEn: 'International Conference Center Hiroshima',
+  sprintDateEn: 'August 23, 2026 Sprint Day',
+  conferenceLocationEn: 'International Conference Center Hiroshima (Conference Days)',
+  sprintLocationEn: 'Hiroshima University Higashi-Senda Campus (Sprint Day)',
+  locationJa: '広島国際会議場 (カンファレンス) / 広島大学 東千田キャンパス (スプリント)',
 }
 
 export const Keynotes: Keynote[] = [


### PR DESCRIPTION
## 概要
最新情報に合わせて Hero セクションの開催日・会場情報を更新しました。

## 変更内容
- スプリント日付の「(仮)」/「(tentative)」表記を削除
- スプリント当日の会場として「広島大学 東千田キャンパス (Hiroshima University Higashi-Senda Campus)」を追加
- Hero セクションでカンファレンス会場とスプリント会場を別々に表示
  - 英語: Venue 欄を2行構成に変更
  - 日本語: 1行に両会場を併記

🤖 Generated with [Claude Code](https://claude.com/claude-code)